### PR TITLE
Allow prosemirror to be installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     }
   ],
   "dependencies": {
-    "prosemirror": "^0.0.1"
+    "prosemirror": "git+https://github.com/ProseMirror/prosemirror.git"
   },
   "devDependencies": {
     "babel": "^5.4.7",


### PR DESCRIPTION
This references the prosemirror dependency explicitly as a git repo, as there is no package for prosemirror yet on npm.