### PR TITLE
Update dino demo to appear in menu

### DIFF
--- a/src/client/demo_dino.js
+++ b/src/client/demo_dino.js
@@ -30,7 +30,7 @@ Dino.prototype.serializeDOM = node => elt("img", {
 Dino.attachCommand("insertDino", type => ({
   label: "Insert dino",
   exec(pm) {
-    
+
   }
 }))
 
@@ -48,7 +48,8 @@ Dino.attachCommand("selectDino", nodeType => ({
     {name: "Dino type", type: "select", options: dinoOptions, default: dinoOptions[0]}
   ],
   display: "select",
-  info: {menuGroup: "inline", menuRank: 99}
+  menuGroup: "inline",
+  menuRank: 99
 }))
 
 const dinoSchema = new Schema(defaultSchema.spec.updateNodes({dino: Dino}))


### PR DESCRIPTION
Thanks to peteb in this [discuss thread](https://discuss.prosemirror.net/t/dino-menu-does-not-appear/79) for pointing out that the syntax has changed for adding items to the menu.

I made the corresponding change, rebuilt the demo site and now the dino button is added to the menu and will insert dinos into the document.

The alternative method of adding a dino to the document using something like `[pterodactyl]` still doesn't work though.

Refs #7 