### PR TITLE
Update highlight plugin interface

### DIFF
--- a/src/demo/track.js
+++ b/src/demo/track.js
@@ -25,7 +25,7 @@ const trackPlugin = new Plugin({
 const highlightPlugin = new Plugin({
   state: {
     init() { return {deco: DecorationSet.empty, commit: null} },
-    applyAction(action, prev, state) {
+    applyAction(action, highlighted, prev, state) {
       if (action.type == "highlightCommit" && prev.commit != action.commit) {
         let tState = trackPlugin.getState(state)
         let decos = tState.blameMap

--- a/src/demo/track.js
+++ b/src/demo/track.js
@@ -25,7 +25,7 @@ const trackPlugin = new Plugin({
 const highlightPlugin = new Plugin({
   state: {
     init() { return {deco: DecorationSet.empty, commit: null} },
-    applyAction(action, highlighted, prev, state) {
+    applyAction(action, prev, oldState, state) {
       if (action.type == "highlightCommit" && prev.commit != action.commit) {
         let tState = trackPlugin.getState(state)
         let decos = tState.blameMap


### PR DESCRIPTION
The `applyAction` interface is: `applyAction(action: Action, value: T, oldState: EditorState, newState: EditorState) → T`. By omitting the old value, the highlights were always operating on the old state, not the current one. This caused me some headscratches with de-syncs from the tracked plugin.

This may be on purpose, I'm not sure. I was adapting this demo for different needs and ran into the problem.