### PR TITLE
Remove usage of private Fragment.size API

### DIFF
--- a/src/collab/client/collab.js
+++ b/src/collab/client/collab.js
@@ -75,7 +75,7 @@ class EditorConnection {
 
     if (newEditState) {
       let sendable
-      if (newEditState.doc.content.size > 40000) {
+      if (newEditState.doc.nodeSize > 40000) {
         if (this.state.comm != "detached") this.report.failure("Document too big. Detached.")
         this.state = new State(newEditState, "detached")
       } else if ((this.state.comm == "poll" || action.requestDone) && (sendable = this.sendable(newEditState))) {


### PR DESCRIPTION
There's actually many places throughout the different packages that are using this private API. Presumably they should all be changed to use `.nodeSize - 2`? Alternatively we could make `Fragment.size` a public API — which actually seems like a reasonable change.