### PR TITLE
minor typo: fixing link in schema guide

### DIFF
--- a/pages/docs/guides/schema/index.md
+++ b/pages/docs/guides/schema/index.md
@@ -113,7 +113,7 @@ atom (string, number, bool, null) or a reference to an attribute in
 the parent node, written with a prefixed dot, for example
 `"table_row[width=.width]"`.
 
-By default, nodes do not support [marks][##model.Mark]. When desired,
+By default, nodes do not support [marks](##model.Mark). When desired,
 you have to explicitly allow them using angle bracket syntax. So
 `"text*"` means “text without marks”, whereas `"text<em>*"` means
 “text with optional emphasis mark”, `"text<em strong>*"` text with


### PR DESCRIPTION
Fixing link from http://prosemirror.net/docs/guides/schema/ to http://prosemirror.net/docs/ref/#model.Mark

Just a typo in Markdown syntax, rendered like this currently:
<img width="425" alt="screen shot 2017-08-01 at 11 21 17 am" src="https://user-images.githubusercontent.com/767530/28840397-b07ca69e-76ab-11e7-913d-88480777da4e.png">
