### PR TITLE
[collab demo] Correctly update user count

### DIFF
--- a/src/collab/client/collab.js
+++ b/src/collab/client/collab.js
@@ -239,7 +239,6 @@ document.querySelector("#changedoc").addEventListener("click", e => {
 })
 
 function userString(n) {
-  if (n == null) n = 1
   return "(" + n + " user" + (n == 1 ? "" : "s") + ")"
 }
 

--- a/src/collab/server/instance.js
+++ b/src/collab/server/instance.js
@@ -56,9 +56,13 @@ class Instance {
         this.comments.created(event)
     }
 
-    while (this.waiting.length) this.waiting.pop().finish()
+    sendUpdates()
     scheduleSave()
     return {version: this.version, commentVersion: this.comments.version}
+  }
+
+  sendUpdates() {
+    while (this.waiting.length) this.waiting.pop().finish()
   }
 
   // : (Number)
@@ -88,14 +92,23 @@ class Instance {
   }
 
   collectUsers() {
+    const oldUserCount = this.userCount
     this.users = Object.create(null)
     this.userCount = 0
     this.collecting = null
     for (let i = 0; i < this.waiting.length; i++)
-      this.registerUser(this.waiting[i].ip)
+      this._registerUser(this.waiting[i].ip)
+    if (this.userCount != oldUserCount) this.sendUpdates()
   }
 
   registerUser(ip) {
+    if (!(ip in this.users)) {
+      this._registerUser(ip)
+      this.sendUpdates()
+    }
+  }
+
+  _registerUser(ip) {
     if (!(ip in this.users)) {
       this.users[ip] = true
       this.userCount++

--- a/src/collab/server/server.js
+++ b/src/collab/server/server.js
@@ -125,7 +125,8 @@ function outputEvents(inst, data) {
                       commentVersion: inst.comments.version,
                       steps: data.steps.map(s => s.toJSON()),
                       clientIDs: data.steps.map(step => step.clientID),
-                      comment: data.comment})
+                      comment: data.comment,
+                      users: data.users})
 }
 
 // An endpoint for a collaborative document instance which


### PR DESCRIPTION
This fixes two issues:
1. The response to the `events` long poll does not contain a `users` property, although `EditorConnection::poll` expects it. After the first remote event, the displayed user count is always 1.
2. Connects and disconnects don't trigger a response to the long poll. so displayed user counts are not updated until a remote event occurs.