### PR TITLE
Guide: Fix Plugin example

### DIFF
--- a/markdown/guide/view.md
+++ b/markdown/guide/view.md
@@ -178,7 +178,7 @@ which can only be provided directly to the view.
 function maxSizePlugin(max) {
   return new Plugin({
     props: {
-      editable(state) { return state.content.size < max }
+      editable(state) { return state.doc.content.size < max }
     }
   })
 }


### PR DESCRIPTION
Issue: `content` is a property of `state.doc`