### PR TITLE
Fix double apply of steps

### DIFF
--- a/markdown/guide/collab.md
+++ b/markdown/guide/collab.md
@@ -46,9 +46,8 @@ class Authority {
   receiveSteps(version, steps, clientID) {
     if (version != this.steps.length) return
 
-    // Apply and accumulate new steps
+    // Accumulate new steps
     steps.forEach(step => {
-      this.doc = step.apply(this.doc).doc
       this.steps.push(step)
       this.stepClientIDs.push(clientID)
     })

--- a/markdown/guide/collab.md
+++ b/markdown/guide/collab.md
@@ -36,8 +36,7 @@ JavaScript environment as the editors.
 
 ```javascript
 class Authority {
-  constructor(doc) {
-    this.doc = doc
+  constructor() {
     this.steps = []
     this.stepClientIDs = []
     this.onNewSteps = []


### PR DESCRIPTION
As `view.dispatch(collab.receiveTransaction(...))` already updates the doc, the authority should not do this itself as well.

This caused the first received foreign step to be applied twice for me.