### PR TITLE
fix overflow on mobile and increase mobile padding

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -76,11 +76,12 @@ header > * { z-index: 2; position: relative; }
 
 header {
   position: relative;
-  padding: 62px 3px 0;
+  padding: 62px 6px 0;
 }
 
 header.frontpage {
   color: white;
+  overflow-x: hidden;
   margin-bottom: 40px;
 }
 
@@ -105,7 +106,11 @@ h2 a:link, h2 a:visited, h3 a:link, h3 a:visited, h4 a:link, h4 a:visited {
 
 code, pre { font-size: 14px; }
 h2 code, h3 code { font-size: inherit; }
-pre { line-height: 22px; padding-left: 20px; }
+pre {
+  line-height: 22px;
+  padding-left: 20px;
+  overflow-x: auto;
+}
 
 a.blocklink:hover {
   color: #0075ff;
@@ -202,12 +207,12 @@ nav#toc ul ul {
 }
 
 article {
-  padding: 10px 3px 100px;
+  padding: 10px 6px 100px;
 }
 
 footer {
   margin-bottom: 54px;
-  padding: 14px 3px 0;
+  padding: 14px 6px 0;
   color: white;
   background: black;
 }


### PR DESCRIPTION
I noticed there were a few overflow and readability related issues on the ProseMirror mobile site. 

## 1. On mobile the header banner causes the screen to horizontally scroll. Due to how the css treats the body tag (https://stackoverflow.com/questions/36794306/body-tag-overflow-auto-visible)
Example of issue:
![image](https://user-images.githubusercontent.com/3388704/63656122-348f7b00-c745-11e9-9515-b95ca2e0c381.png)

To resolve this I added `overflow-x: hidden;` to the body tag. For some reason this adjusted how the height of the body was calculated (I'm not totally sure why 😅). In order to make the footer look the same I had to switch the spacing from margin to padding.

## 2. On mobile the code examples were clipping over the edge and there was no way to view them
Example of issue:
![image](https://user-images.githubusercontent.com/3388704/63656132-5d177500-c745-11e9-9484-e6afcc5216ed.png)

To resolve this I added overflow-x auto to the pre tags. Allowing them to be scrolled horizontally.

3. On mobile the body text hugs the side of the screen very closely. Making it a less pleasant reading experience.
Example of issue:
![image](https://user-images.githubusercontent.com/3388704/63656156-918b3100-c745-11e9-9149-f1ac45eaaa88.png)

To resolve this I added a horizontal padding of 16px in the mobile media query.

Screenshot after changes:
![image](https://user-images.githubusercontent.com/3388704/63656217-0f4f3c80-c746-11e9-88b6-07cbb78ab202.png)