### PR TITLE
Make website style normal in small screen device

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -82,6 +82,7 @@ header {
 header.frontpage {
   color: white;
   margin-bottom: 40px;
+  overflow: hidden;
 }
 
 header > h1 {
@@ -348,6 +349,10 @@ a.sponsor {
   display: block;
   margin: .5em 0 .5em 20px;
   min-width: 45%;
+}
+
+a.sponsor img {
+  max-width: 100%;
 }
 
 a.sponsor.diamond img { height: 100px }


### PR DESCRIPTION
There are two problem when open website `https://prosemirror.net` in small screen:
1. the header h1::before pseudo-element are too big if no 'overflow:hidden' to restrict it.
2. the img in sponsor are too big when show in small screen device.