### PR TITLE
Add "rollup-plugin-node-builtins" package

### DIFF
--- a/bin/build-example.js
+++ b/bin/build-example.js
@@ -13,7 +13,8 @@ let options = {
     require("rollup-plugin-node-resolve")({main: true, preferBuiltins: false}),
     require("rollup-plugin-json")(),
     require("rollup-plugin-commonjs")(),
-    require("rollup-plugin-buble")()
+    require("rollup-plugin-buble")(),
+    require("rollup-plugin-node-builtins")()
   ],
   external,
   output: {format: "iife", globals}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "rollup-plugin-buble": "^0.16.0",
     "rollup-plugin-commonjs": "^8.2.4",
     "rollup-plugin-json": "^2.3.0",
+    "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-uglify": "^2.0.1",
     "tariff": "0.1.0"


### PR DESCRIPTION
Add "rollup-plugin-node-builtins" package for markdown-it to build markdown-example correctly.

The related issue is: Fixes #111 