### PR TITLE
Prevent comments from inheriting editor text font style

### DIFF
--- a/example/collab/index.html
+++ b/example/collab/index.html
@@ -8,6 +8,7 @@
   display: block;
   padding: 0;
   margin: 0;
+  font-style: normal;
 }
 
 .tooltip-wrapper {


### PR DESCRIPTION
before:
 
![Kapture 2020-08-24 at 00 58 45](https://user-images.githubusercontent.com/1177031/91037744-40ef2380-e5a5-11ea-8789-84750b034540.gif)


after:

![Kapture 2020-08-24 at 00 59 38](https://user-images.githubusercontent.com/1177031/91037841-6b40e100-e5a5-11ea-8e2d-c323853f2835.gif)

