### PR TITLE
Fix api use typos

### DIFF
--- a/markdown/guide/transform.md
+++ b/markdown/guide/transform.md
@@ -119,7 +119,7 @@ steps in them, using an abstraction called
 and allows you to map through them in one go.
 
 ```javascript
-let tr = new Transaction(myDoc)
+let tr = new Transform(myDoc)
 tr.split(10)    // split a node, +2 tokens at 10
 tr.delete(2, 5) // -3 tokens at 2
 console.log(tr.mapping.map(15)) // → 14


### PR DESCRIPTION
When I learn Prosemirror from the guide, meet with following error:

```shell
node_modules/prosemirror-transform/dist/index.js:814
  var $pos = this.doc.resolve(pos), before = prosemirrorModel.Fragment.empty, after = prosemirrorModel.Fragment.empty;
                      ^

TypeError: Cannot read property 'resolve' of undefined

```

So I replace the `Transaction` with  `Transform`, and it's pass, So I thought it's maybe a API typos.

Then with this PR 😄 