### PR TITLE
Make scrollbar visible on MacOS Chrome.

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -29,7 +29,7 @@ html {
 }
 
 body {
-  margin: 0 0 5px;
+  margin: 0;
   line-height: 1.45;
   font-size: 16px;
   overflow-y: scroll;
@@ -209,7 +209,7 @@ article {
 }
 
 footer {
-  padding: 14px 6px 0;
+  padding: 14px 6px;
   color: white;
   background: black;
 }

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -24,14 +24,13 @@
 }
 
 html {
-  background: black;
+  background: white;
   font-family: 'Source Sans Pro';
 }
 
 body {
   margin: 0 0 5px;
   line-height: 1.45;
-  background: white;
   font-size: 16px;
   overflow-y: scroll;
   overflow-x: hidden;


### PR DESCRIPTION
Chrome on MacOS changes the color of the scrollbar based on `html`'s
background color. Currently, since `html`'s background is black,
Chrome makes the scrollbar white, which renders it invisible against
the white `body`.

Screenshot of current behavior:

<img width="1012" alt="Screen Shot 2022-02-22 at 13 17 10" src="https://user-images.githubusercontent.com/3211874/155222521-deaacb8b-6f2d-4c42-ad9e-f188834ba09e.png">

Screenshot of fixed behavior:

<img width="1005" alt="Screen Shot 2022-02-22 at 13 17 25" src="https://user-images.githubusercontent.com/3211874/155222542-a328cf92-7f45-49c1-a6f9-4584bdfe1abe.png">