### PR TITLE
fix <code> margin in "pre > code" code block

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -109,6 +109,9 @@ pre {
   padding-left: 20px;
   overflow-x: auto;
 }
+pre > code {
+  margin: 0;
+}
 
 a.blocklink:hover {
   color: #0075ff;


### PR DESCRIPTION
first line of code block not align with others

caused by `code { margin: 0 2px; }`

![图片](https://github.com/ProseMirror/website/assets/22849803/806b9c86-3842-419a-9030-5c9a8adf4d2b)

fix with `pre > code`, if no other affect